### PR TITLE
fixing account bug

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -51,8 +51,9 @@ if (app.get('env') === 'development') {
 if (app.get('env') === 'production') {
     admin.initializeApp({
         credential: admin.credential.cert({
-            "private_key": process.env.FIREBASE_PRIVATE_KEY,
-            "client_email": process.env.FIREBASE_CLIENT_EMAIL,
+            "projectId": process.env.FIREBASE_PROJECT_ID,
+            "clientEmail": process.env.FIREBASE_CLIENT_EMAIL,
+            "privateKey": process.env.FIREBASE_PRIVATE_KEY,
         }),
         databaseURL: process.env.FIREBASE_DATABASE_URL
     });


### PR DESCRIPTION
Database security rules were preventing users from writing to the users collection - that's been updated with a rule that lets them write only to their own node (no-one elses).  This should fix #61 .  

Also updated an additional bug concerning requirement of the node admin sdk for firebase now asing for project_id when initializing the admin connection.  I've added that as well and an environment config variable in Heroku for production version.